### PR TITLE
Fixed rendering last line and did a cargo fmt

### DIFF
--- a/command/src/lib.rs
+++ b/command/src/lib.rs
@@ -1,9 +1,7 @@
 use ropey::Rope;
 use std::ffi::c_void;
 
-use termion::{
-    cursor::{Goto, Show},
-};
+use termion::cursor::{Goto, Show};
 use types::{
     BackBuffer, ClientIndex, Cmd, DeleteDirection, Direction, GlobalData, Mode, Msg, Point, Rect,
     Utils,

--- a/core/src/editor.rs
+++ b/core/src/editor.rs
@@ -9,7 +9,7 @@ use log4rs::encode::pattern::PatternEncoder;
 use std::collections::HashMap;
 use std::default::Default;
 use std::ffi::c_void;
-use std::io::{Write};
+use std::io::Write;
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::{fs, path, time};
 

--- a/cursor/src/lib.rs
+++ b/cursor/src/lib.rs
@@ -1,8 +1,6 @@
 use ropey::Rope;
 
-use termion::{
-    cursor::{Goto, Show},
-};
+use termion::cursor::{Goto, Show};
 use types::{
     BackBuffer, BufferIndex, ClientIndex, Cmd, DeleteDirection, Direction, GlobalData, JumpType,
     Mode, Msg, Point, Rect, SecondaryMap, Utils,
@@ -83,7 +81,7 @@ fn get_new_x_position(cursor: &Cursor, rope: &Rope) -> u16 {
     let Cursor { position, stored_x } = cursor;
     std::cmp::min(
         std::cmp::max(position.x, *stored_x),
-        rope.line(position.y as usize).len_chars() as u16,
+        std::cmp::max(1, rope.line(position.y as usize).len_chars() as u16),
     )
 }
 
@@ -141,7 +139,7 @@ pub fn update(
                                     }
                                 }
                                 Down => {
-                                    if (cursor.position.y as usize) + 1 < rope.len_lines() {
+                                    if (cursor.position.y as usize) + 2 < rope.len_lines() {
                                         cursor.position.y += 1;
                                     }
                                     if (cursor.position.y as usize)

--- a/lang-rust/src/colors.rs
+++ b/lang-rust/src/colors.rs
@@ -43,15 +43,11 @@ pub fn get_color_from_tag(tag: &str) -> Option<Color> {
 
 pub fn get_color_from_severity(severity: Severity) -> Color {
     match severity {
-        Severity::Error => Color {
-            r: 255,
-            g: 0,
-            b: 0,
-        },
+        Severity::Error => Color { r: 255, g: 0, b: 0 },
         Severity::WeakWarning => Color {
             r: 255,
             g: 255,
             b: 0,
-        }
+        },
     }
 }


### PR DESCRIPTION
The problem was that for some reason `Rope.lines()` doesn't behave well sometimes. Easier (and cleaner tbh) to just do it myself.