### PR TITLE
I6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,5 @@ members = [
     "command",
     "lang-rust",
     "buffer-editor",
+    "registers",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,5 @@ members = [
     "cursor",
     "command",
     "lang-rust",
+    "buffer-editor",
 ]

--- a/buffer-editor/Cargo.toml
+++ b/buffer-editor/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "buffer-editor"
+version = "0.1.0"
+authors = ["Pearce Keesling <pearce.keesling@lifeomic.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[lib]
+name = "buffereditor"
+crate-type = ["dylib"]
+
+[dependencies]
+types = { path = "../types" }

--- a/buffer-editor/src/lib.rs
+++ b/buffer-editor/src/lib.rs
@@ -57,6 +57,11 @@ pub fn update(
                     rope.insert_char(index, *c);
                     send_cmd(*client_index, BufferModified);
                 }
+                InsertStringAtPoint(string, point) => {
+                    let index = get_ropey_index_from_point(point, &rope);
+                    rope.insert(index, &string);
+                    send_cmd(*client_index, BufferModified);
+                }
                 DeleteCharRange(start, end) => {
                     rope.remove(get_char_range(start, end, &rope));
                     send_cmd(*client_index, BufferModified);

--- a/buffer-editor/src/lib.rs
+++ b/buffer-editor/src/lib.rs
@@ -1,0 +1,85 @@
+use types::{
+    BackBuffer, Buffer, BufferIndex, Client, ClientIndex, Cmd, Color, DeleteDirection, Direction,
+    GlobalData, JumpType, Mode, Msg, Point, Rect, Rope, SecondaryMap, Utils,
+};
+
+#[derive(Debug, Default)]
+struct State {
+    value: bool, // This just makes it possible to build
+}
+
+#[no_mangle]
+pub fn render(
+    _global_data: &GlobalData,
+    _client: &ClientIndex,
+    _back_buffer: &mut BackBuffer,
+    _utils: &Utils,
+    _data_ptr: *mut c_void,
+) {
+}
+
+fn get_ropey_index_from_point(position: &Point, rope: &Rope) -> usize {
+    rope.line_to_char(position.y as usize) + position.x as usize - 1
+}
+
+fn get_char_range(
+    position: &Point,
+    selection_anchor: &Point,
+    rope: &Rope,
+) -> std::ops::RangeInclusive<usize> {
+    let start_index = get_ropey_index_from_point(position, rope);
+    let end_index = get_ropey_index_from_point(selection_anchor, rope);
+    if start_index < end_index {
+        start_index..=end_index
+    } else {
+        end_index..=start_index
+    }
+}
+
+#[no_mangle]
+pub fn update(
+    global_data: &mut GlobalData,
+    cmd: &Msg,
+    _utils: &Utils,
+    send_cmd: &Box<Fn(ClientIndex, Cmd)>,
+    _data_ptr: *mut c_void,
+) {
+    // let _data: Box<State> = unsafe { Box::from_raw(data_ptr as *mut State) };
+    use Cmd::*;
+    match cmd {
+        Msg::Cmd(client_index, cmd) => {
+            let client = &global_data.clients[*client_index];
+            let current_buffer = &mut global_data.buffers[client.buffer];
+            let rope = &mut current_buffer.rope;
+            match cmd {
+                InsertCharAtPoint(c, point) => {
+                    let index = get_ropey_index_from_point(point, &rope);
+                    rope.insert_char(index, *c);
+                    send_cmd(*client_index, BufferModified);
+                }
+                DeleteCharRange(start, end) => {
+                    rope.remove(get_char_range(start, end, &rope));
+                    send_cmd(*client_index, BufferModified);
+                }
+                _ => {}
+            }
+        }
+        _ => {}
+    };
+    // std::mem::forget(data);
+}
+
+use std::ffi::c_void;
+
+#[no_mangle]
+pub fn init() -> *mut c_void {
+    Box::into_raw(Box::new(State::default())) as *mut c_void
+}
+
+#[no_mangle]
+pub fn cleanup(data: *mut c_void) {
+    unsafe {
+        let ptr = Box::from_raw(data);
+        drop(ptr);
+    }
+}

--- a/input/src/lib.rs
+++ b/input/src/lib.rs
@@ -61,6 +61,12 @@ pub fn update(
                         ':' => {
                             send_cmd(*client, Cmd::ChangeMode(Mode::Command));
                         }
+                        'y' => {
+                            send_cmd(*client, Cmd::Yank);
+                        }
+                        'p' => {
+                            send_cmd(*client, Cmd::Paste);
+                        }
                         _ => {}
                     },
                     Event::Key(Key::Ctrl(c)) => match c {

--- a/registers/Cargo.toml
+++ b/registers/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "registers"
+name = "buffer-editor"
 version = "0.1.0"
 authors = ["Pearce Keesling <pearce.keesling@lifeomic.com>"]
 edition = "2018"
@@ -7,7 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [lib]
-name = "registers"
+name = "buffereditor"
 crate-type = ["dylib"]
 
 [dependencies]

--- a/registers/src/lib.rs
+++ b/registers/src/lib.rs
@@ -1,0 +1,61 @@
+use types::{
+    BackBuffer, Buffer, BufferIndex, Client, ClientIndex, Cmd, Color, DeleteDirection, Direction,
+    GlobalData, JumpType, Mode, Msg, Point, Rect, Rope, SecondaryMap, Utils,
+};
+
+#[derive(Debug, Default)]
+struct State {
+    register: String,
+}
+
+#[no_mangle]
+pub fn render(
+    _global_data: &GlobalData,
+    _client: &ClientIndex,
+    _back_buffer: &mut BackBuffer,
+    _utils: &Utils,
+    _data_ptr: *mut c_void,
+) {
+}
+
+#[no_mangle]
+pub fn update(
+    global_data: &mut GlobalData,
+    cmd: &Msg,
+    _utils: &Utils,
+    send_cmd: &Box<Fn(ClientIndex, Cmd)>,
+    data_ptr: *mut c_void,
+) {
+    let mut data: Box<State> = unsafe { Box::from_raw(data_ptr as *mut State) };
+    use Cmd::*;
+    match cmd {
+        Msg::Cmd(client_index, cmd) => {
+            match cmd {
+                YankValue(val) => {
+                    data.register = val.clone();
+                }
+                PasteAtPoint(position) => {
+                    send_cmd(*client_index, InsertStringAtPoint(data.register.clone(), position.clone()));
+                }
+                _ => {}
+            }
+        }
+        _ => {}
+    };
+    std::mem::forget(data);
+}
+
+use std::ffi::c_void;
+
+#[no_mangle]
+pub fn init() -> *mut c_void {
+    Box::into_raw(Box::new(State::default())) as *mut c_void
+}
+
+#[no_mangle]
+pub fn cleanup(data: *mut c_void) {
+    unsafe {
+        let ptr = Box::from_raw(data);
+        drop(ptr);
+    }
+}

--- a/types/src/commands.rs
+++ b/types/src/commands.rs
@@ -1,0 +1,23 @@
+use crate::{DeleteDirection, Direction, JumpType, Mode, Point, Rect};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Deserialize, Serialize)]
+pub enum Cmd {
+    MoveCursor(Direction, bool),
+    Quit,
+    Kill,
+    ChangeMode(Mode),
+    InsertChar(char),
+    InsertCharAtPoint(char, Point),
+    DeleteCharRange(Point, Point),
+    DeleteChar(DeleteDirection),
+    Jump(JumpType),
+    RunCommand,
+    WriteBuffer(std::path::PathBuf),
+    LoadFile(std::path::PathBuf),
+    BufferLoaded,
+    BufferModified,
+    SearchFiles,
+    CleanRender,
+    ResizeClient(Rect),
+}

--- a/types/src/commands.rs
+++ b/types/src/commands.rs
@@ -9,6 +9,7 @@ pub enum Cmd {
     ChangeMode(Mode),
     InsertChar(char),
     InsertCharAtPoint(char, Point),
+    InsertStringAtPoint(String, Point),
     DeleteCharRange(Point, Point),
     DeleteChar(DeleteDirection),
     Jump(JumpType),
@@ -20,4 +21,8 @@ pub enum Cmd {
     SearchFiles,
     CleanRender,
     ResizeClient(Rect),
+    Yank,
+    YankValue(String),
+    Paste,
+    PasteAtPoint(Point),
 }

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -1,9 +1,12 @@
 use notify::DebouncedEvent;
-use ropey::{Rope, RopeSlice};
+pub use ropey::{Rope, RopeSlice};
 pub use slotmap::{DefaultKey, KeyData, SecondaryMap, SlotMap};
 use std::os::unix::net::UnixStream;
 
 use termion::event::Event;
+
+mod commands;
+pub use commands::Cmd;
 
 pub type ClientIndex = DefaultKey;
 
@@ -93,25 +96,6 @@ pub struct RemoteCommand(pub ClientIndex, pub Cmd);
 #[derive(Debug, Deserialize, Serialize)]
 pub struct InitializeClient(pub ClientIndex);
 
-#[derive(Debug, Deserialize, Serialize)]
-pub enum Cmd {
-    MoveCursor(Direction, bool),
-    Quit,
-    Kill,
-    ChangeMode(Mode),
-    InsertChar(char),
-    DeleteChar(DeleteDirection),
-    Jump(JumpType),
-    RunCommand,
-    WriteBuffer(std::path::PathBuf),
-    LoadFile(std::path::PathBuf),
-    BufferLoaded,
-    BufferModified,
-    SearchFiles,
-    CleanRender,
-    ResizeClient(Rect),
-}
-
 #[derive(Debug)]
 pub struct Client {
     pub stream: UnixStream,
@@ -129,7 +113,7 @@ pub enum Msg {
     NewClient(UnixStream),
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Default, PartialOrd)]
+#[derive(Debug, Clone, Eq, PartialEq, Default, PartialOrd, Serialize, Deserialize)]
 pub struct Point {
     pub y: u16,
     pub x: u16,


### PR DESCRIPTION
Refactors to do all edits through `buffer-editor` so that cursor can be concerned with fewer things. 

Added the yank/paste buffer. Skipped doing full-blown registers for the moment. Not a super important part of my work-flow so I decided not to worry about it. Also didn't make delete move removed text to the buffer, I might later if I want.